### PR TITLE
Correct path for retrodebugger submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
   url = https://github.com/LouDnl/Vice-USBSID.git
 [submodule "examples/retrodebugger"]
   path = examples/retrodebugger
-  url = git@github.com:LouDnl/RetroDebugger.git
+	url = https://github.com/LouDnl/RetroDebugger.git
 [submodule "examples/USBSID-Pico-driver"]
   path = examples/USBSID-Pico-driver
   url = https://github.com/LouDnl/USBSID-Pico-driver.git


### PR DESCRIPTION
This will allow `git clone --recursive-submodules ...` to be used when an SSH key is not available.