### PR TITLE
Make 'reset_state' a volatile bool

### DIFF
--- a/src/sid.c
+++ b/src/sid.c
@@ -36,7 +36,8 @@ extern uint8_t *sid_memory;
 #else
 extern uint8_t __not_in_flash("usbsid_buffer") sid_memory[(0x20 * 4)] __attribute__((aligned(2 * (0x20 * 4))));
 #endif
-extern bool paused_state, reset_state;
+extern bool paused_state;
+extern volatile bool reset_state;
 extern int usbdata;
 
 /* config.c */

--- a/src/usbsid.c
+++ b/src/usbsid.c
@@ -56,7 +56,8 @@ char cdc = 'C', asid = 'A', midi = 'M', sysex = 'S', wusb = 'W', uart = 'U';
 bool web_serial_connected = false;
 
 double cpu_mhz = 0, cpu_us = 0, sid_hz = 0, sid_mhz = 0, sid_us = 0;
-bool paused_state = false, reset_state = false;
+bool paused_state = false;
+volatile bool reset_state = false;
 bool auto_config = false;
 bool offload_ledrunner = false;
 
@@ -254,7 +255,7 @@ void __no_inline_not_in_flash_func(process_buffer)(uint8_t * itf, uint32_t * n)
   uint8_t command = ((sid_buffer[0] & PACKET_TYPE) >> 6);
   uint8_t subcommand = (sid_buffer[0] & COMMAND_MASK);
   uint8_t n_bytes = (sid_buffer[0] & BYTE_MASK);
-  while (reset_state == 1) { asm("nop"); };  /* Stall if in reset state */
+  while (reset_state) /* Stall if in reset state */ ;
 
   if (command == CYCLED_WRITE) {
     // n_bytes = (n_bytes == 0) ? 4 : n_bytes; /* if byte count is zero, this is a single write packet */


### PR DESCRIPTION
This variable will be changed from multiple contexts and there is a loop polling it to ensure it is safe to continue.

However, during the loop the variable will not be changed, and the compiler can conclude that therefore it never will, making it an infinite loop if the variable was initially true. This is likely why the "nop" was added: it is a workaround and not guaranteed to work properly in newer versions of the compiler/different build options.

Fix it properly by marking the variable volatile and removing the nop.